### PR TITLE
Docs update from nexus-sdk

### DIFF
--- a/nexus-sdk/CLI.md
+++ b/nexus-sdk/CLI.md
@@ -79,6 +79,14 @@ After the period of time configured in our Tool Registry, let the Tool developer
 
 > This command requires that a wallet is connected to the CLI.
 
+**`nexus tool list`**
+
+List all Nexus Tools available in the Tool Registry. This reads the dynamic object directly from Sui.
+
+> This command requires that a wallet is connected to the CLI.
+
+---
+
 ### `nexus dag`
 
 Set of commands for managing JSON DAGs.

--- a/nexus-sdk/toolkit-rust.md
+++ b/nexus-sdk/toolkit-rust.md
@@ -185,6 +185,8 @@ underlying HTTP server that adheres to the [Nexus Tool interface][nexus-next-too
 
 It has a flexible interface that accepts an `Into<SocketAddr>` value and a struct that `impl NexusTool`.
 
+If using the `bootstrap!` macro without the `Into<SocketAddr>` argument, a `BIND_ADDR` environment variable can be provided. This variable needs to be a string that can `.parse::<SocketAddr>`.
+
 ```rs
 use nexus_toolkit::*;
 


### PR DESCRIPTION
This PR syncs updates to documentation from the [nexus-sdk](https://github.com/Talus-Network/nexus-sdk) repository (source commit: ef057b630cbb97366e0135339459b209cbbf38f4)