### PR TITLE
Docs update from nexus-next

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -33,8 +33,8 @@
   * [Sui Move Conventions](nexus-next/conventions/Sui-Move.md)
   * [Crate: Leader](nexus-next/crates/Leader.md)
     * [Leader Sui Transactions](nexus-next/crates/Sui-Tx.md)
-  * [Agent Development](nexus-next/SAP/Index.md)
-  * [Default SAP](nexus-next/SAP/Default-SAP.md)
+  * [Agent Development](nexus-next/TAP/Index.md)
+  * [Default TAP](nexus-next/TAP/Default-TAP.md)
   * [Tool](nexus-next/Tool.md)
   * [Gas Service](nexus-next/Gas-Service.md)
   * [Nexus Core API docs](developer-docs/index/nexus-core-api-docs/README.md)
@@ -63,8 +63,3 @@
 
 * [OpenAI Chat Completion](tools/llm-openai-chat-completion/README.md)
 * [Math](tools/math/README.md)
-
-## Looking for a home
-
-* [nexus-next/TAP/Default-TAP.md](nexus-next/TAP/Default-TAP.md)
-* [nexus-next/TAP/Index.md](nexus-next/TAP/Index.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -63,3 +63,8 @@
 
 * [OpenAI Chat Completion](tools/llm-openai-chat-completion/README.md)
 * [Math](tools/math/README.md)
+
+## Looking for a home
+
+* [nexus-next/TAP/Default-TAP.md](nexus-next/TAP/Default-TAP.md)
+* [nexus-next/TAP/Index.md](nexus-next/TAP/Index.md)

--- a/nexus-next/Gas-Service.md
+++ b/nexus-next/Gas-Service.md
@@ -34,7 +34,7 @@ Gas tickets represent prepaid access to tool invocations. They can be configured
 Gas tickets and budgets can be associated with different scopes:
 
 1. **Execution Scope**: Specific to a single DAG execution.
-2. **Worksheet Type Scope**: Applies to all executions of a specific worksheet type, i.e. the SAP.
+2. **Worksheet Type Scope**: Applies to all executions of a specific worksheet type, i.e. the TAP.
 3. **Invoker Address Scope**: Applies to all executions initiated by a specific address.
 
 {% hint style="warning" %}

--- a/nexus-next/TAP/Default-TAP.md
+++ b/nexus-next/TAP/Default-TAP.md
@@ -1,0 +1,357 @@
+# Default Talus Agent Package (TAP)
+
+## Overview
+
+The Default TAP is a useful helper component for Nexus agent developers. It serves as a template or base implementation of a Talus Agent Package (TAP) that can be used for examples, tests, or to run JSON-defined DAGs from the CLI.
+
+## Interface Compliance
+
+The Default TAP implements the [Nexus Interface V1][nexus-interface-v1]  specification, which defines the required functionality for any Talus Agent Package to integrate with the Nexus workflow engine. Key interface requirements include:
+
+1. **Version Management**
+   - Must declare and maintain interface version compatibility.
+   - Must support version checking for backward compatibility.
+
+2. **Workflow Management**
+   - Must handle worksheet management and state tracking.
+   - Must support tool evaluation confirmation.
+
+3. **Authorization**
+   - Must implement witness-based authorization.
+   - Must support package upgrade mechanisms.
+
+For detailed interface requirements, see the [Nexus Interface Documentation][nexus-interface] .
+
+<!-- Gitbook syntax -->
+{% hint style="info" %} In the code snippets below, we reference some Sui Move patterns (e.g. hot potato), please refer to the [primitives pakcage doc][packages-primitives] for more information on the approach taken here. {% endhint %}
+
+### DefaultTAP Structure
+
+The agent will be represented by the `DefaultTAP` struct, which is a shared object that contains:
+- `id`: A unique identifier for the TAP instance.
+- `witness`: A Bag containing authorization tokens for package identification and upgrade management.
+- `iv`: The interface version (currently v1) that clients can use to determine compatibility.
+
+```rust
+use nexus_interface::version::InterfaceVersion;
+use sui::bag::{Self, Bag};
+use sui::object::UID;
+
+/// Shared object implementing the Nexus Interface v1 specification.
+public struct DefaultTAP has key {
+    id: UID,
+    /// On package upgrade, we'll want to replace the previous witness with a
+    /// new one that identifies the new package.
+    ///
+    /// This is because as of now Sui doesn't give us access to the package ID
+    /// so we need to always create a new type and query it from the type via
+    /// its type name.
+    witness: Bag,
+    /// Clients can search the smart agent shared object for this type to
+    /// determine what interface to expect.
+    iv: InterfaceVersion,
+}
+```
+
+### Constructor and Leader Registration
+
+The DefaultTAP is created using the `new()` constructor function, which:
+1. Creates a new DefaultTAP instance with a unique ID.
+2. Initializes a witness token for package identification.
+3. Sets the Nexus interface version to v1.
+4. Registers the TAP with the Nexus leader.
+
+```rust
+use nexus_interface::version::{Self, InterfaceVersion};
+use sui::bag::{Self, Bag};
+use sui::object::UID;
+use sui::transfer::share_object;
+
+public(package) fun new(ctx: &mut TxContext) {
+    let default_sap = DefaultSAP {
+        id: object::new(ctx),
+        witness: {
+            let mut b = bag::new(ctx);
+            b.add(b"witness", DefaultSAPV1Witness { id: object::new(ctx) });
+            b
+        },
+        iv: version::v(1),
+    };
+
+    announce_interface_package(
+        default_sap.get_witness(),
+        vector[object::id(&default_sap)],
+    );
+
+    share_object(default_sap);
+}
+
+/// with...
+public struct DefaultSAPV1Witness has key, store {
+    id: UID,
+}
+```
+
+### Worksheet
+
+The worksheet function is a core requirement of the Nexus Interface V1 specification. It creates a proof of UID (Unique Identifier) that serves as a "stamp collector" for tracking workflow execution state. This proof:
+
+1. Acts as a hot-potato object that collects execution confirmations from Nexus components like the DAG.
+2. Must be constructed with a type defined in the same package and module that implements the interface.
+3. Is used to verify that required operations have been performed in the correct sequence.
+
+```rust
+use nexus_interface::version::InterfaceVersion;
+use nexus_primitives::proof_of_uid::{Self, ProofOfUID};
+
+public fun worksheet(self: &DefaultSAP): ProofOfUID {
+    self.iv.expect_v(1);
+    proof_of_uid::new_with_type(&self.get_witness().id, self.get_witness())
+}
+```
+
+### Tool Evaluation Confirmation
+
+The `confirm_tool_eval_for_walk` function is another core requirement of the Nexus Interface V1 specification. It is invoked by the Nexus Leader after a workflow contract has advanced the DAG to:
+
+1. Consume the worksheet hot-potato.
+2. Verify that all required confirmations have been collected.
+3. Complete the tool evaluation cycle for a specific walk in the workflow.
+
+```rust
+use nexus_interface::version::InterfaceVersion
+
+public fun confirm_tool_eval_for_walk(
+    self: &mut DefaultSAP,
+    worksheet: ProofOfUID,
+) {
+    self.iv.expect_v(1);
+    worksheet.consume(&self.get_witness().id);
+}
+
+/// with...
+fun get_witness(self: &DefaultSAP): &DefaultSAPV1Witness {
+    self.witness.borrow(b"witness")
+}
+```
+
+## DAG Execution
+
+The Default TAP works in conjunction with the Nexus workflow engine, which provides:
+
+1. **DAG Implementation**
+   - Directed Acyclic Graph data structure for modeling complex workflows.
+   - Support for vertices, edges, and input/output ports.
+   - Entry group management for workflow initiation.
+
+2. **Tool Registry**
+   - Registration and management of available tools.
+
+3. **Tool Invocation**
+   - Support for tool execution invocation, onchain or offchain.
+   - Leader capability management.
+
+Where the above steps effectively ensure interface compliance, the (default) TAP also needs to enable DAG execution.
+
+### Begin DAG Execution
+
+The DAG execution is initiated through the `begin_dag_execution` function.
+
+This function:
+
+1. Takes a DAG and entry vertices with their input data.
+2. Creates a worksheet to track execution state.
+3. Begins execution of the entry group through the DAG.
+4. Requests the network to execute walks through the DAG.
+5. Shares the execution object for tracking progress.
+
+```rust
+use nexus_primitives::data::NexusData;
+use nexus_primitives::proof_of_uid::{Self, ProofOfUID};
+use nexus_workflow::dag::{DAG, Vertex, InputPort, EntryGroup};
+
+/// Invokes the provided entry vertex on a DAG with the provided input data for
+/// each input port.
+public fun begin_dag_execution(
+    self: &mut DefaultSAP,
+    dag: &DAG,
+    network: ID,
+    entry_group: EntryGroup,
+    mut with_vertex_inputs: VecMap<Vertex, VecMap<InputPort, NexusData>>,
+    ctx: &mut TxContext,
+) {
+    self.iv.expect_v(1);
+
+    let mut entry_vertices = vector[];
+    let mut with_vertices_inputs = vector[];
+    while (!with_vertex_inputs.is_empty()) {
+        let (vertex, inputs) = with_vertex_inputs.pop();
+        entry_vertices.push_back(vertex);
+        with_vertices_inputs.push_back(inputs);
+    };
+
+    let mut worksheet = self.worksheet();
+
+    let (mut execution, ticket) = dag.begin_execution_of_entry_group(
+        &mut worksheet,
+        network,
+        entry_group,
+        entry_vertices,
+        with_vertices_inputs,
+        ctx
+    );
+
+    worksheet.consume(&self.get_witness().id);
+
+    dag.request_network_to_execute_walks(&mut execution, ticket, ctx);
+
+    public_share_object(execution);
+}
+```
+
+## Security Considerations
+
+- The TAP uses witness tokens for authorization as required by the [Nexus Interface][nexus-interface].
+- Interface version checking ensures compatibility.
+- Worksheet proofs ensure state integrity.
+- Tool execution is properly isolated.
+<!-- TODO: refer to Security analysis after integrating Stephen's whitepaper section on it -->
+
+## Full Module Code
+
+Toggle to see the full module code for the default TAP:
+<details>
+
+<summary>Toggle code</summary>
+
+```rust
+module nexus_workflow::default_sap;
+
+//! Module defining a default smart agent package with no added logic but
+//! executing the provided DAG. This can be used for examples, tests or to run
+//! JSON-defined DAGs from the CLI or via other means.
+
+use nexus_interface::version::InterfaceVersion;
+use nexus_primitives::data::NexusData;
+use nexus_primitives::proof_of_uid::{Self, ProofOfUID};
+use nexus_workflow::dag::{DAG, Vertex, InputPort, EntryGroup};
+
+use sui::bag::{Self, Bag};
+use sui::transfer::{share_object, public_share_object};
+use sui::vec_map::{VecMap};
+
+/// Shared object.
+public struct DefaultSAP has key {
+    id: UID,
+    /// On package upgrade, we'll want to replace the previous witness with a
+    /// new one that identifies the new package.
+    ///
+    /// This is because as of now Sui doesn't give us access to the package ID
+    /// so we need to always create a new type and query it from the type via
+    /// its type name.
+    witness: Bag,
+    /// Clients can search the smart agent shared object for this type to
+    /// determine what interface to expect.
+    iv: InterfaceVersion,
+}
+
+/// Used to identify the package::module deployment.
+///
+/// Will also serve as authorization token to change list of shared objects for
+/// nexus interface v1.
+public struct DefaultSAPV1Witness has key, store {
+    id: UID,
+}
+
+public(package) fun new(ctx: &mut TxContext) {
+    let default_sap = DefaultSAP {
+        id: object::new(ctx),
+        witness: {
+            let mut b = bag::new(ctx);
+            b.add(b"witness", DefaultSAPV1Witness { id: object::new(ctx) });
+            b
+        },
+        iv: nexus_interface::version::v(1),
+    };
+
+    nexus_interface::v1::announce_interface_package(
+        default_sap.get_witness(),
+        vector[object::id(&default_sap)],
+    );
+
+    share_object(default_sap);
+}
+
+// === Client entry ===
+
+/// Invokes the provided entry vertex on a DAG with the provided input data for
+/// each input port.
+#[allow(lint(share_owned))]
+public fun begin_dag_execution(
+    self: &mut DefaultSAP,
+    dag: &DAG,
+    network: ID,
+    entry_group: EntryGroup,
+    mut with_vertex_inputs: VecMap<Vertex, VecMap<InputPort, NexusData>>,
+    ctx: &mut TxContext,
+) {
+    self.iv.expect_v(1);
+
+    let mut entry_vertices = vector[];
+    let mut with_vertices_inputs = vector[];
+    while (!with_vertex_inputs.is_empty()) {
+        let (vertex, inputs) = with_vertex_inputs.pop();
+        entry_vertices.push_back(vertex);
+        with_vertices_inputs.push_back(inputs);
+    };
+
+    let mut worksheet = self.worksheet();
+
+    let (mut execution, ticket) = dag.begin_execution_of_entry_group(
+        &mut worksheet,
+        network,
+        entry_group,
+        entry_vertices,
+        with_vertices_inputs,
+        ctx
+    );
+
+    worksheet.consume(&self.get_witness().id);
+
+    dag.request_network_to_execute_walks(&mut execution, ticket, ctx);
+
+    public_share_object(execution);
+}
+
+// === Nexus interface v1 ===
+
+/// Nexus resources can prove that they did a thing.
+public fun worksheet(self: &DefaultSAP): ProofOfUID {
+    self.iv.expect_v(1);
+
+    proof_of_uid::new_with_type(&self.get_witness().id, self.get_witness())
+}
+
+/// One calls this after workflow contract is done with advancing the DAG.
+public fun confirm_tool_eval_for_walk(
+    self: &mut DefaultSAP,
+    worksheet: ProofOfUID,
+) {
+    self.iv.expect_v(1);
+
+    worksheet.consume(&self.get_witness().id);
+}
+
+fun get_witness(self: &DefaultSAP): &DefaultSAPV1Witness {
+    self.witness.borrow(b"witness")
+}
+
+```
+
+</details>
+
+<!-- List of references -->
+
+[nexus-interface]: ../packages/Nexus-Interface.md
+[nexus-interface-v1]: ../packages/Nexus-Interface.md#v1
+[packages-primitives]: ../packages/Primitives.md

--- a/nexus-next/TAP/Index.md
+++ b/nexus-next/TAP/Index.md
@@ -1,0 +1,42 @@
+# Agent Development
+
+Nexus, as the implementation of the Talus Agentic Framework (TAF),  provides a useful set of abstractions and, both onchain and offchain components that orchestrate the development, registration and discovery of tools, the composition of those tools in workflows and finally the workflow execution. Find the definitions of these terms in the [glossary][glossary] in case they are unfamiliar.
+
+As a result, Nexus greatly facilitates building Talus Agents for [agent developers][actors]. 
+
+<!-- Gitbook syntax -->
+{% hint style="info" %} A Talus agent is an onchain identity associated with one or more onchain assets and workflow services {% endhint %}
+
+## Development Requirements
+
+There's a number of ways an agent developer could build their agents, with varying levels of complexity:
+
+- Construct the workflow(s) (DAGs) AND write a Sui Move "Talus Agent Package" (TAP) that holds the workflows(s) as well as some custom business logic related to it. This is the most complex as it requires the agent developer to develop a custom TAP package.
+
+
+- Only construct the workflow(s) (DAGs) and use the [_default TAP_][default-tap] to hold the workflow DAG and provide the functionality to execute it. The default TAP provides a template TAP implementation and reduces the development work to the configuration of the workflow DAG(s).
+
+- Write a Sui Move TAP that uses existing workflows in a _plug-and-play_ manner. There could be additional business logic added to the TAP. This is an intermediate level of complexity.
+
+<!-- Gitbook Syntax -->
+{% hint style="success" %} How to choose the way to build?
+
+The choice of how to build the agent will be determined by weighing: 
+
+- familiarity with Sui Move, 
+- the need for custom logic to govern workflow execution, payment etc. 
+- the availability of existing workflows that meet the application's needs {% endhint %}
+
+## Explore further
+
+Continue learning about agent development with the following sections:
+
+- the [Nexus interface for TAPs][interface] section, outlining what interface the TAP must comply with
+- the reference [default TAP][default-tap] implemenation, that serves as an example for a bare-bones TAP
+
+<!-- List of references -->
+
+[actors]: ../index.md#actors
+[glossary]: ../Glossary.md
+[interface]: ../packages/Nexus-Interface.md
+[default-tap]: ./Default-TAP.md

--- a/nexus-next/index.md
+++ b/nexus-next/index.md
@@ -76,8 +76,8 @@ The components referenced above (onchain Nexus, offchain Nexus and tools) provid
 
 Docs:
 
-* [Agent development](SAP/Index.md)
-* [Default SAP template](SAP/Default-SAP.md)
+* [Agent development](TAP/Index.md)
+* [Default TAP template](TAP/Default-TAP.md)
 
 ## Nexus SDK
 
@@ -85,4 +85,4 @@ Nexus offers tool and [agent developers](index.md#actors) an easy-to-use SDK con
 
 Docs:
 
-* [Nexus SDK documentation](broken-reference)
+* [Nexus SDK documentation](../nexus-sdk/index.md)

--- a/nexus-next/packages/Nexus-Interface.md
+++ b/nexus-next/packages/Nexus-Interface.md
@@ -1,13 +1,13 @@
 # Nexus Interface
 
-Nexus components are designed to be composed into "Smart Agent Packages" (SAPs) that are published on Sui.
-SAPs are typically template Sui packages that are customized for a specific product.
+Nexus components are designed to be composed into "Talus Agent Packages" (TAPs) that are published on Sui.
+TAPs are typically template Sui packages that are customized for a specific product.
 They would include business logic relevant to the product and configurations for the Nexus components.
 
 The configurations typically take the form of `SuiObjectID`s which represent shared objects.
 These shared objects, such as [`DAG`][packages-workflow], are unforced to be invoked in situations described by the business logic.
 
-Some examples of what the business logic in a SAP could do:
+Some examples of what the business logic in a TAP could do:
 
 - check token supply to feature-gate a workflow
 - require a payment component
@@ -17,7 +17,7 @@ Some examples of what the business logic in a SAP could do:
 ## `V1`
 
 Nexus first iteration is focused on the workflow component.
-To comply with the Nexus V1 Interface the SAP must:
+To comply with the Nexus V1 Interface the TAP must:
 
 1. Register itself with the [Nexus leader][crates-leader] by emitting `nexus_interface::v1::AnnounceInterfacePackageEvent` that
    - has a generic parameter `W` which is a type located in the package and module that implements the interface.


### PR DESCRIPTION
This PR syncs updates to documentation from the [nexus-next](https://github.com/Talus-Network/nexus-next) repository (source commit: 374b94b776f3b3f5ecc5664a324243ee4e7128e6)