### PR TITLE
Docs update from nexus-next

### DIFF
--- a/nexus-next/Gas-Service.md
+++ b/nexus-next/Gas-Service.md
@@ -74,7 +74,7 @@ Tools can set a default cost per invocation. When no gas tickets are available, 
 
 ### 2. Gas Extensions
 
-Gas extensions provide alternative payment strategies. The default extension ([`default_gas_extension`](https://github.com/Talus-Network/nexus-next/tree/main/sui/workflow/sources/default_gas_extentsion.move)) implements an expiry-based system where users can:
+Gas extensions provide alternative payment strategies. The default extension implements an expiry-based system where users can:
 
 * Buy access for a specific duration (e.g., 10 minutes).
 * Pay a fixed rate per minute.

--- a/nexus-next/Tool.md
+++ b/nexus-next/Tool.md
@@ -54,7 +54,7 @@ This topic has not yet been discussed in depth and needs addressing.
 
 ## Tool registration
 
-Tools should be register in the Tool Registry using our [CLI][repo-nexus-sdk-cli].
+Tools should be register in the Tool Registry using our [CLI](../nexus-sdk/CLI.md#nexus-tool)
 
 ### Off-chain tools
 
@@ -72,7 +72,3 @@ Our initial focus are off-chain tools.
 ## Tool authorization
 
 Once there are community Tools, we will need a way to authorize communication between the Leader and a Tool. This has been discussed superficially and it needs to be researched in depth in the future.
-
-<!-- List of References -->
-
-[repo-nexus-sdk-cli]: https://github.com/Talus-Network/nexus-sdk/tree/main/cli

--- a/nexus-next/crates/Leader.md
+++ b/nexus-next/crates/Leader.md
@@ -1,7 +1,5 @@
 # Leader
 
-> concerns [`be/leader` crate][repo-leader-crate]
-
 ## Sequence diagram
 
 High-level sequence diagram describing the duties of the Leader.
@@ -94,13 +92,15 @@ There are multiple processes running in parallel in the leader node. These are a
 
 ## High integrity channel
 
-Some parts of the Leader service use a [custom channel implementation][channel-impl] that handles indexing of messages sent over this channel, as well as retries and sweeps of stale messages.
+Some parts of the Leader service use a custom channel implementation that handles indexing of messages sent over this channel, as well as retries and sweeps of stale messages.
 
 Notably, the event listener<>event executor and the event executor<>merchant processes communicate via this channel.
 
 The following state diagrams should highlight the functionality of the channel.
 
-> Note that this channel "assumes" it has a stable Redis connection. There are edge cases, where dropping events is very unlikely, but possible. One such edge case is if sending a message over this channel fails due to Redis being unavailable but the Sui event listener successfully saves the next page cursor to Redis. This can in the future be improved by handling Redis errors within the channel differently (by for example, halting).
+{% hint style="info" %}
+Note that this channel "assumes" it has a stable Redis connection. There are edge cases, where dropping events is very unlikely, but possible. One such edge case is if sending a message over this channel fails due to Redis being unavailable but the Sui event listener successfully saves the next page cursor to Redis. This can in the future be improved by handling Redis errors within the channel differently (by for example, halting).
+{% endhint %}
 
 ### High integrity channel receiver and sender
 
@@ -167,7 +167,3 @@ stateDiagram-v2
     }
 ```
 
-<!-- List of References -->
-
-[repo-leader-crate]: https://github.com/Talus-Network/nexus-next/tree/main/be/leader
-[channel-impl]: https://github.com/Talus-Network/nexus-next/tree/main/be/leader/src/channel.rs

--- a/nexus-next/index.md
+++ b/nexus-next/index.md
@@ -1,6 +1,6 @@
 # 🫀 Nexus Core
 
-This wiki aims to document the technical side of all Nexus components. We will split the documentation into several parts that, albeit distinct projects, work together to form Nexus as a whole.
+This section aims to document the technical side of all core Nexus components. We will split the documentation into several parts that, albeit distinct projects, work together to form Nexus as a whole.
 
 ## Actors
 
@@ -17,8 +17,7 @@ Ubiqutously used terms. Often these terms reference specific parts of the projec
 
 ## Onchain Nexus
 
-The on-chain part of Nexus.\
-Holds the workflow DAG state and requests Tool execution from the Leader. The codebase resides in [this repository](https://github.com/Talus-Network/nexus-next/tree/main/sui).
+The on-chain part of Nexus. Holds the workflow DAG state and requests Tool execution from the Leader. 
 
 Docs:
 
@@ -26,15 +25,13 @@ Docs:
 * [Primitives package](packages/Primitives.md)
 * [Nexus interface package](packages/Nexus-Interface.md)
 
-Epics:
-
-* https://github.com/Talus-Network/nexus-next/issues/9
-* https://github.com/Talus-Network/nexus-next/issues/16
+{% hint style="info" %}
+The Nexus core onchain packages are currently not open sourced. To find all of the function signatures and data structs, please refer to [the reference API documentation](./packages/reference/)
+{% endhint %}
 
 ### [Sui Move Conventions](conventions/Sui-Move.md)
 
-We established a [set of conventions for writing Move code](conventions/Sui-Move.md), some of them unfamiliar outside of the Nexus team.\
-Skim through them before diving into the Move codebase.
+We established a [set of conventions for writing Move code](conventions/Sui-Move.md), some of them unfamiliar outside of the Nexus team. Skim through them before diving into the Move codebase.
 
 ## Offchain Nexus
 
@@ -43,10 +40,6 @@ The main off-chain service. Consumes events produced by the on-chain Workflow, i
 Docs:
 
 * [Leader](crates/Leader.md)
-
-Epics:
-
-* https://github.com/Talus-Network/nexus-next/issues/53
 
 ## [Tools](Tool.md)
 
@@ -63,12 +56,6 @@ Some examples of what a Tool is:
 Docs:
 
 * [Tool](Tool.md)
-
-Epics:
-
-* https://github.com/Talus-Network/nexus-next/issues/69
-* https://github.com/Talus-Network/nexus-next/issues/30
-* https://github.com/Talus-Network/nexus-next/issues/31
 
 ## [Agent Development](SAP/Index.md)
 

--- a/nexus-next/packages/Primitives.md
+++ b/nexus-next/packages/Primitives.md
@@ -1,7 +1,5 @@
 # Primitives Package
 
-> concerns [`sui/primitives` package][repo-primitives-package]
-
 Exports types that allow two Sui packages, A and B, to communicate with each other in an authenticated way without using explicit Move dependencies. Instead, A and B have a shared dependency on this package, `nexus_primitives`.
 
 ## Why is this useful?

--- a/nexus-next/packages/Workflow.md
+++ b/nexus-next/packages/Workflow.md
@@ -1,7 +1,5 @@
 # Workflow Package
 
-> concerns [`sui/workflow` package][repo-workflow-package]
-
 This Sui package exports data structures and algorithms which orchestrate off-chain computation.
 The workflow engine is an integral part of the on-chain control plane.
 
@@ -46,7 +44,9 @@ In a nutshell, the workflow engine executes walks over a directed acyclic graph 
 10. If a walk reaches a vertex that cannot be immediately scheduled for execution then the walk halts as consumed.
 11. Input ports designated as part of an `EntryGroup` cannot have default values. Default values are only permitted for input ports that are *not* part of any entry group.
 
-> These rules are statically validated by the [Nexus CLI][nexus-sdk-cli] if using JSON definitions of DAGs.
+{% hint style="info" %}
+These rules are statically validated by the [Nexus CLI][nexus-sdk-cli] if using JSON definitions of DAGs.
+{% endhint %}
 
 ![Shows legend](../images/dag-rules/dag.legend.png)
 
@@ -169,7 +169,7 @@ Events in our Nexus packages can contain these data types:
   - `{ name: String }`
 - `VertexKind`
   - enumeration over the kind of vertices in a DAG
-  - see [the `dag` module][repo-workflow-package-dag] for this type
+  - see the `dag` module for this type
 - `InputPort`
   - a unique name of an input port in a vertex
   - `{ name: String }`
@@ -178,7 +178,7 @@ Events in our Nexus packages can contain these data types:
   - `{ from: { variant: String, port: String }, to: { vertex: String, port: String } }`
 - `NexusData`
   - represents some data within Nexus framework
-  - see [the `data` module][repo-primitives-package-data] for this type
+  - see the `data` module for this type
 - `VertexEvaluation`
   - represents what should be the inputs to a vertex
   - `{ ports_to_data: Map<InputPort, NexusData> }`
@@ -206,14 +206,11 @@ The amount of `SUI` locked and the interval after which they can be reclaimed is
 - We have considered a stricter rule `5.` where `InputPort` can have only one incoming `OutputVariantPort`.
   However, relaxing this rule into its current form meant expressive workflows and simpler runtime state management in exchange for more complex static analysis algorithm.
   This trade-off was deemed worthy.
-- When using the [`ProofOfUid` primitive][repo-primitives-package-data], it must be created with a type that matches the `UID`.
+- When using the `ProofOfUid` primitive, it must be created with a type that matches the `UID`.
   The type should be considered an authorization ticket and should be treated just as any other capability type.
 
 <!-- List of references -->
 
-[repo-workflow-package]: https://github.com/Talus-Network/nexus-next/tree/main/sui/workflow
-[repo-workflow-package-dag]: https://github.com/Talus-Network/nexus-next/tree/main/sui/workflow/sources/dag.move
-[repo-primitives-package-data]: https://github.com/Talus-Network/nexus-next/tree/main/sui/primitives
 [tool-definitions]: ../Tool.md#tool-definitions
 [crates-leader]: ./crates/Leader.md
 [reference-workflow]: ./reference/nexus_workflow/dag.md 


### PR DESCRIPTION
This PR syncs updates to documentation from the [nexus-next](https://github.com/Talus-Network/nexus-next) repository (source commit: 5d32576be0f72c99f23c0c132a4442f824304b10)