### PR TITLE
FIX: Various fixes for the gitbook v0.1.0 view

### DIFF
--- a/nexus-sdk/guides/math-branching-quickstart.md
+++ b/nexus-sdk/guides/math-branching-quickstart.md
@@ -51,6 +51,7 @@ graph TD
 ## Prerequisites
 
 - [Nexus CLI](setup.md#install-the-nexus-cli) installed.
+- A clone of the [`nexus-sdk` repository](https://github.com/talus-network/nexus-sdk) to run the examples.
 - A configured Sui wallet for the publish step (can skip this step if just validating). Follow the [Getting Started section in the Sui Docs](https://docs.sui.io/guides/developer/getting-started) to get you set up.
 
 {% hint style="info" %}
@@ -72,10 +73,10 @@ This should show the following tools running:
 
 ## 1. Clone the repository
 
-Clone the nexus-sdk repository and navigate to it
+Clone the `nexus-sdk` repository and navigate to it:
 
-```code
-git clone --depth 1 --branch v0.1.0 https://github.com/Talus-Network/nexus-sdk.git
+```bash
+git clone --branch v0.1.0 https://github.com/talus-network/nexus-sdk
 cd nexus-sdk
 ```
 

--- a/nexus-sdk/guides/math-branching-quickstart.md
+++ b/nexus-sdk/guides/math-branching-quickstart.md
@@ -10,9 +10,9 @@ In the quickstart example we'll use a simple conceptual workflow consisting of s
 
 The [`math_branching.json` DAG](https://github.com/Talus-Network/nexus-sdk/blob/v0.1.0/cli/src/dag/_dags/math_branching.json) takes a number input, adds `-3` to it, checks if the result is negative, zero, or positive, and then performs one of three operations:
 
-* If negative: Multiply by `-3`
-* If positive: Multiply by `7`
-* If zero: Add `1`
+- If negative: Multiply by `-3`
+- If positive: Multiply by `7`
+- If zero: Add `1`
 
 Here's a visual representation of the workflow:
 
@@ -23,16 +23,16 @@ graph TD
         Def1([b = -3]) --> A;
         A -- "result" --> B{"is_negative<br>(math.i64.cmp@1)"};
         Def2([b = 0]) --> B;
-        
+
         B -- "lt (a < 0)" --> C["mul_by_neg_3<br>(math.i64.mul@1)"];
         Def3([b = -3]) --> C;
-        
+
         B -- "gt (a > 0)" --> D["mul_by_7<br>(math.i64.mul@1)"];
         Def4([b = 7]) --> D;
-        
+
         B -- "eq (a == 0)" --> E["add_1<br>(math.i64.add@1)"];
         Def5([b = 1]) --> E;
-        
+
         C -- "result" --> Result1((Final Result));
         D -- "result" --> Result2((Final Result));
         E -- "result" --> Result3((Final Result));
@@ -41,7 +41,7 @@ graph TD
     classDef input fill:#23D3F8,stroke:#000000,stroke-width:2px,color:#000000;
     classDef output fill:#76EFB6,stroke:#000000,stroke-width:2px,color:#000000;
     classDef default fill:#FFFFCB,stroke:#000000,stroke-width:1px,color:#000000;
-    
+
     class A,C,D,E,B tool;
     class Result1,Result2,Result3 output;
     class Input input;
@@ -50,8 +50,8 @@ graph TD
 
 ## Prerequisites
 
-* [Nexus CLI](setup.md#install-the-nexus-cli) installed.
-* A configured Sui wallet for the publish step (can skip this step if just validating). Follow the [Getting Started section in the Sui Docs](https://docs.sui.io/guides/developer/getting-started) to get you set up.
+- [Nexus CLI](setup.md#install-the-nexus-cli) installed.
+- A configured Sui wallet for the publish step (can skip this step if just validating). Follow the [Getting Started section in the Sui Docs](https://docs.sui.io/guides/developer/getting-started) to get you set up.
 
 {% hint style="info" %}
 In this example we will publish a DAG consisting of Nexus Tools that are running somewhere and registered (the URL can be found as metadata in the tool registry). If you were running your own tools and needed to register them, check out [Nexus CLI tool commands](../cli.md#nexus-tool) to find out how to do this.
@@ -65,10 +65,10 @@ nexus tool list
 
 This should show the following tools running:
 
-* xyz.taluslabs.math.i64.add@1
-* xyz.taluslabs.math.i64.cmp@1
-* xyz.taluslabs.math.i64.mul@1
-* ...
+- xyz.taluslabs.math.i64.add@1
+- xyz.taluslabs.math.i64.cmp@1
+- xyz.taluslabs.math.i64.mul@1
+- ...
 
 ## 1. Validate the DAG
 
@@ -97,9 +97,10 @@ Take note of the DAG ID returned by this command - you'll need it in the next st
 To execute the published DAG, use its ID and provide input for the entry vertex:
 
 **Input JSON Structure:**
+
 ```json
 // Example Input: provide value 10 to port 'a' of 'add_input_and_default'
-'{"add_input_and_default": {"a": 10}}'
+"{\"add_input_and_default\": {\"a\": 10}}"
 ```
 
 **Test Different Execution Paths:**
@@ -124,18 +125,18 @@ The `--inspect` flag automatically retrieves and displays the execution details 
 
 By trying different inputs, you can see how the DAG's branching logic directs execution flow:
 
-* `a=10` triggers the "greater than" path
-* `a=-5` triggers the "less than" path
-* `a=3` triggers the "equal to" path
+- `a=10` triggers the "greater than" path
+- `a=-5` triggers the "less than" path
+- `a=3` triggers the "equal to" path
 
 This demonstrates how Nexus DAGs can implement conditional logic and branching based on data values.
 
 ## Find the Results
 
-When you execute the DAG via the `nexus dag execute` command, a successful output will return you a transaction digest and DAG execution object ID. You can use both to further examine the execution, using either the Sui CLI or an explorer.
+When you execute the DAG via the `nexus dag execute` command, a successful output will return you a transaction digest and DAG execution object ID. You can use both to further examine the execution, using either the Sui CLI or an [explorer](https://explorer.devnet.taluslabs.dev/).
 
 ## Next Steps
 
-* Read the full [Agent Builder Guide](math-branching-dag-builder.md) to understand how this DAG is constructed
-* Study the [DAG Construction Guide](dag-construction.md) for more advanced DAG features
-* Try building your own DAG with different tools and logic flows
+- Read the full [Agent Builder Guide](math-branching-dag-builder.md) to understand how this DAG is constructed
+- Study the [DAG Construction Guide](dag-construction.md) for more advanced DAG features
+- Try building your own DAG with different tools and logic flows

--- a/nexus-sdk/guides/math-branching-quickstart.md
+++ b/nexus-sdk/guides/math-branching-quickstart.md
@@ -70,9 +70,18 @@ This should show the following tools running:
 - xyz.taluslabs.math.i64.mul@1
 - ...
 
-## 1. Validate the DAG
+## 1. Clone the repository
 
-First, validate the DAG structure using the Nexus CLI:
+Clone the nexus-sdk repository and navigate to it
+
+```code
+git clone --depth 1 --branch v0.1.0 https://github.com/Talus-Network/nexus-sdk.git
+cd nexus-sdk
+```
+
+## 2. Validate the DAG
+
+Validate the DAG structure using the Nexus CLI:
 
 ```bash
 nexus dag validate --path cli/src/dag/_dags/math_branching.json
@@ -80,7 +89,7 @@ nexus dag validate --path cli/src/dag/_dags/math_branching.json
 
 This step ensures the DAG structure meets all Nexus workflow rules before attempting to publish it.
 
-## 2. Publish the DAG
+## 3. Publish the DAG
 
 Once validated, publish the DAG to make it executable:
 
@@ -92,7 +101,7 @@ nexus dag publish --path cli/src/dag/_dags/math_branching.json
 
 Take note of the DAG ID returned by this command - you'll need it in the next step.
 
-## 3. Execute the DAG with Different Inputs
+## 4. Execute the DAG with Different Inputs
 
 To execute the published DAG, use its ID and provide input for the entry vertex:
 

--- a/nexus-sdk/guides/setup.md
+++ b/nexus-sdk/guides/setup.md
@@ -84,8 +84,7 @@ export NEXUS_USERNAME="my-username"
 export NEXUS_PASSWORD="my-password"
 ```
 
-Then, configure your Nexus CLI to connect to the\
-Talus `devnet` by running:
+Then, configure your Nexus CLI to connect to the Talus `devnet` by running:
 
 ```bash
 nexus conf --sui.net devnet \

--- a/nexus-sdk/guides/setup.md
+++ b/nexus-sdk/guides/setup.md
@@ -84,6 +84,13 @@ export NEXUS_USERNAME="my-username"
 export NEXUS_PASSWORD="my-password"
 ```
 
+Clone the nexus-sdk repository
+
+```code
+git clone --depth 1 --branch v0.1.0 https://github.com/Talus-Network/nexus-sdk.git
+cd nexus-sdk
+```
+
 Then, configure your Nexus CLI to connect to the\
 Talus `devnet` by running:
 

--- a/nexus-sdk/guides/setup.md
+++ b/nexus-sdk/guides/setup.md
@@ -80,8 +80,8 @@ Once you receive your credentials, first set them as environment variables in yo
 Replace `my-username` and `my-password` with your actual credentials:
 
 ```bash
-export USERNAME="my-username"
-export PASSWORD="my-password"
+export NEXUS_USERNAME="my-username"
+export NEXUS_PASSWORD="my-password"
 ```
 
 Then, configure your Nexus CLI to connect to the\
@@ -89,8 +89,8 @@ Talus `devnet` by running:
 
 ```bash
 nexus conf --sui.net devnet \
-  --sui.basic-auth-user "$USERNAME" \
-  --sui.basic-auth-password "$PASSWORD" \
+  --sui.basic-auth-user "$NEXUS_USERNAME" \
+  --sui.basic-auth-password "$NEXUS_PASSWORD" \
   --nexus.primitives-pkg-id "0x0783a33d62f22820d78d343492ae261015f83757e5de3302bf189c04b38086d5" \
   --nexus.workflow-pkg-id "0xc338f469d744408e9efaafc9ede711fb11e29eb65536009b443479fb6e8ee502" \
   --nexus.default-sap-object-id "0x6b7c6c579d35c214ee63c3c3f3e8534abe391a4b7f86c5aeb992d80ee1466ce6" \
@@ -101,8 +101,8 @@ nexus conf --sui.net devnet \
 Next, create a `.envrc` file to conveniently store your RPC and faucet URLs:
 
 ```bash
-echo 'export SUI_RPC_URL=https://rpc.ssfn.devnet.production.taluslabs.dev' > .envrc
-echo 'export SUI_FAUCET_URL=https://YOUR_USERNAME:YOUR_PASSWORD@faucet.devnet.production.taluslabs.dev/gas' >> .envrc
+echo "export SUI_RPC_URL=https://rpc.ssfn.devnet.production.taluslabs.dev" > .envrc
+echo "export SUI_FAUCET_URL=https://$NEXUS_USERNAME:$NEXUS_PASSWORD@faucet.devnet.production.taluslabs.dev/gas" >> .envrc
 ```
 
 Activate these environment variables using:
@@ -124,7 +124,7 @@ environment:
 
 ```bash
 sui client new-env --alias devnet --rpc $SUI_RPC_URL \
-  --basic-auth YOUR_USERNAME:YOUR_PASSWORD
+  --basic-auth "$NEXUS_USERNAME":"$NEXUS_PASSWORD"
 sui client switch --env devnet
 ```
 

--- a/nexus-sdk/guides/setup.md
+++ b/nexus-sdk/guides/setup.md
@@ -84,13 +84,6 @@ export NEXUS_USERNAME="my-username"
 export NEXUS_PASSWORD="my-password"
 ```
 
-Clone the nexus-sdk repository
-
-```code
-git clone --depth 1 --branch v0.1.0 https://github.com/Talus-Network/nexus-sdk.git
-cd nexus-sdk
-```
-
 Then, configure your Nexus CLI to connect to the\
 Talus `devnet` by running:
 
@@ -167,5 +160,4 @@ and log in using the credentials provided earlier.
 
 ---
 
-After completing these steps, you are ready to build and execute workflows using\
-the Nexus SDK. To build your first workflow, check the [Dev Quickstart guide](math-branching-quickstart.md).
+After completing these steps, you are ready to build and execute workflows using the Nexus SDK. To build your first workflow, check the [Dev Quickstart guide](math-branching-quickstart.md).

--- a/nexus-sdk/guides/setup.md
+++ b/nexus-sdk/guides/setup.md
@@ -162,7 +162,8 @@ sui client balance tally
 
 ## Access Devnet Sui Explorer
 
-Open the [Talus Sui Explorer](https://explorer.devnet.taluslabs.dev/) and request an access code.
+Open the [Talus Sui Explorer](https://explorer.devnet.taluslabs.dev/)\
+and log in using the credentials provided earlier.
 
 ---
 

--- a/nexus-sdk/guides/setup.md
+++ b/nexus-sdk/guides/setup.md
@@ -10,9 +10,9 @@ Follow these steps to install the Nexus CLI and set up your environment:
 
 Make sure you have installed:
 
-* [Rust](https://rustup.rs/) (latest stable)
-* [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html)
-* [Sui](https://docs.sui.io/guides/developer/getting-started)
+- [Rust](https://rustup.rs/) (latest stable)
+- [Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html)
+- [Sui](https://docs.sui.io/guides/developer/getting-started)
 
 ### Install the Nexus CLI
 
@@ -24,6 +24,7 @@ brew install nexus-cli
 ```
 
 or in one step:
+
 ```bash
 brew install talus-network/tap/nexus-cli
 ```
@@ -61,7 +62,8 @@ cargo install nexus-cli \
 nexus --version
 ```
 
-it should print:
+It should print:
+
 ```bash
 nexus-cli 0.1.0
 ```
@@ -74,13 +76,21 @@ credentials. To request access, please submit your details using the form\
 provided in the navigation bar.
 {% endhint %}
 
-Once you receive your credentials, configure your Nexus CLI to connect to the\
+Once you receive your credentials, first set them as environment variables in your terminal.\
+Replace `my-username` and `my-password` with your actual credentials:
+
+```bash
+export USERNAME="my-username"
+export PASSWORD="my-password"
+```
+
+Then, configure your Nexus CLI to connect to the\
 Talus `devnet` by running:
 
 ```bash
 nexus conf --sui.net devnet \
-  --sui.basic-auth-user YOUR_USERNAME \
-  --sui.basic-auth-password YOUR_PASSWORD \
+  --sui.basic-auth-user "$USERNAME" \
+  --sui.basic-auth-password "$PASSWORD" \
   --nexus.primitives-pkg-id "0x0783a33d62f22820d78d343492ae261015f83757e5de3302bf189c04b38086d5" \
   --nexus.workflow-pkg-id "0xc338f469d744408e9efaafc9ede711fb11e29eb65536009b443479fb6e8ee502" \
   --nexus.default-sap-object-id "0x6b7c6c579d35c214ee63c3c3f3e8534abe391a4b7f86c5aeb992d80ee1466ce6" \
@@ -91,11 +101,9 @@ nexus conf --sui.net devnet \
 Next, create a `.envrc` file to conveniently store your RPC and faucet URLs:
 
 ```bash
-export SUI_RPC_URL=https://YOUR_USERNAME:YOUR_PASSWORD@rpc.ssfn.devnet.production.taluslabs.dev
-export SUI_FAUCET_URL=https://YOUR_USERNAME:YOUR_PASSWORD@faucet.devnet.production.taluslabs.dev/gas
+echo 'export SUI_RPC_URL=https://rpc.ssfn.devnet.production.taluslabs.dev' > .envrc
+echo 'export SUI_FAUCET_URL=https://YOUR_USERNAME:YOUR_PASSWORD@faucet.devnet.production.taluslabs.dev/gas' >> .envrc
 ```
-
-where you need to substitute the previously given credentials for `YOUR_USERNAME` and `YOUR_PASSWORD` accordingly.
 
 Activate these environment variables using:
 
@@ -149,7 +157,7 @@ sui client balance tally
 
 Open the [Talus Sui Explorer](https://explorer.devnet.taluslabs.dev/) and request an access code.
 
-***
+---
 
 After completing these steps, you are ready to build and execute workflows using\
 the Nexus SDK. To build your first workflow, check the [Dev Quickstart guide](math-branching-quickstart.md).

--- a/nexus-sdk/guides/setup.md
+++ b/nexus-sdk/guides/setup.md
@@ -155,8 +155,7 @@ sui client balance tally
 
 ## Access Devnet Sui Explorer
 
-Open the [Talus Sui Explorer](https://explorer.devnet.taluslabs.dev/)\
-and log in using the credentials provided earlier.
+Open the [Talus Sui Explorer](https://explorer.devnet.taluslabs.dev/) and log in using the credentials provided earlier.
 
 ---
 


### PR DESCRIPTION
This PR is fixing following issues:

- .envrc file is created as part of running the export command
- username:password is renamed to NEXUS_USERNAME, NEXUS_PASSWORD env variables, used later on for subsequent commands. The NEXUS_ prefix is added to prevent clashes with other variables
- Added instruction to clone the nexus-sdk repo (needed for Dev quickstart page)
- Fixed factually incorrect statement about Sui Explorer login