### PR TITLE
fix typo in tool.md

### DIFF
--- a/nexus-next/tool.md
+++ b/nexus-next/tool.md
@@ -27,7 +27,7 @@ xyz.taluslabs.llm.openai-chat-completion@1
 
 2. `type`
 
-Straighforward, and enum with `offchain` and `onchain` values.
+Straightforward, and enum with `offchain` and `onchain` values.
 
 3. `url`
 


### PR DESCRIPTION

```markdown

Fixed a spelling error in `nexus-next/tool.md` where "Straighforward" was corrected to "Straightforward".

```

